### PR TITLE
emdb's updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "presets": [
       "stage-0",
       "es2015"
+    ],
+    "plugins": [
+      "transform-object-rest-spread"
     ]
   },
   "lint-staged": {
@@ -36,6 +39,7 @@
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.0",
     "babel-jest": "^21.0.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "eslint": "^4.6.1",

--- a/src/index.js
+++ b/src/index.js
@@ -52,17 +52,13 @@ const prefixInternalActionType = actionType =>
   `internal-${ACTION_TYPE_PREFIX}${actionType}`;
 
 const mapMethodsByInternalActionType = mapMethods.reduce((memo, mapMethod) => {
-  return Object.assign({}, memo, {
-    [prefixInternalActionType(mapMethod)]: mapMethod
-  });
+  return { ...memo, [prefixInternalActionType(mapMethod)]: mapMethod };
 }, {});
 
 export const MapActionTypes = mapEvents
   .concat(specialCases)
   .reduce((memo, mapEvent) => {
-    return Object.assign({}, memo, {
-      [mapEvent]: prefixOutgoingActionType(mapEvent)
-    });
+    return { ...memo, [mapEvent]: prefixOutgoingActionType(mapEvent) };
   }, {});
 
 export const MapActionCreators = mapMethods


### PR DESCRIPTION
To test this package, I did the following:

```sh
$ cd mapbox-gl-redux
$ npm i
$ npm run build
$ npm-internal publish --dev
```

and then imported what I needed; for example:

```js
import { ReduxMapControl } from '@mapbox/mapbox-gl-redux';
```
---

The only update I made based on my experimentation in https://github.com/mapbox/print-a-map/pull/33 was replacing the object spread operators with `Object.assign({}, target, source)`. Alternatively, we can add the [`es2015` preset and the `transform-object-rest-spread` plugin](http://redux.js.org/docs/recipes/UsingObjectSpreadOperator.html).

Will the publishing workflow for this module will automatically run `npm run build`?

cc @tristen 
